### PR TITLE
Browser detection with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "win-utils",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Helper libraries for the win evolutionary library. Built for NPM/Component.",
   "keywords": [
     "Neural Network",

--- a/uuid/cuid.js
+++ b/uuid/cuid.js
@@ -77,8 +77,11 @@ var isBrowser = (typeof process == 'undefined' || typeof process.pid == 'undefin
 
 api.fingerprint = isBrowser ?
   function browserPrint() {
-      return pad((navigator.mimeTypes.length +
-          navigator.userAgent.length).toString(36) +
+      // navigator.Navigator is available on a web worker
+      var mimeTypesLength = navigator.mimeTypes ? navigator.mimeTypes.length : '';
+      var userAgentLength = navigator.userAgent.length;
+      return pad((mimeTypesLength +
+          userAgentLength).toString(36) +
           api.globalCount().toString(36), 4);
   }
 : function nodePrint() {
@@ -106,7 +109,16 @@ api.globalCount = function globalCount() {
 
             //global count only ever called inside browser environment
             //lets loop through and count the keys in window -- then cahce that as part of our fingerprint
-        for (i in window) {
+
+        var globalVar;
+        if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
+          // if condition from http://stackoverflow.com/a/18002694/169858
+          globalVar = self;
+        } else {
+          globalVar = window;
+        }
+
+        for (i in globalVar ) {
             count++;
         }
 

--- a/uuid/cuid.js
+++ b/uuid/cuid.js
@@ -73,7 +73,7 @@ api.slug = function slug() {
 };
 
 //fingerprint changes based on nodejs or component setup
-var isBrowser = (typeof process == 'undefined');
+var isBrowser = (typeof process == 'undefined' || typeof process.pid == 'undefined');
 
 api.fingerprint = isBrowser ?
   function browserPrint() {


### PR DESCRIPTION
To be able to use _neatjs_ with _webpack_, the **isBrowser** boolean assignment in the _win-utils_ dependency must also check if **process.pid** is `undefined`, as when running a _webpack_ distribution in a browser, the **process** variable is indeed set, but it's **pid** attribute is not.

Currently I'm using an _npm-shrinkwrap_ to override the _neatjs_ dependencies to use my _win-utils_ fork:  https://github.com/bthj/wavekilde/blob/master/npm-shrinkwrap.json
